### PR TITLE
feat: Inherit from `collections.UserList` for `BaseModel` parent class

### DIFF
--- a/ondemandutils/models/_model.py
+++ b/ondemandutils/models/_model.py
@@ -84,6 +84,9 @@ class BaseModel(UserDict):
 
         super().__init__(obj, **kwargs)
 
+    def __setitem__(self, key, value):
+        super().__setitem__(key, value.dict() if isinstance(value, BaseModel) else value)
+
     def __or__(self, other):
         if not isinstance(other, type(self)):
             raise TypeError(f"Expected `{self.__class__.__name__}`, not {type(other)}.")

--- a/ondemandutils/models/_model.py
+++ b/ondemandutils/models/_model.py
@@ -84,9 +84,6 @@ class BaseModel(UserDict):
 
         super().__init__(obj, **kwargs)
 
-    def __repr__(self):
-        return f"{self.__class__.__name__}({', '.join(f'{k}={v}' for k, v in self.items())})"
-
     def __or__(self, other):
         if not isinstance(other, type(self)):
             raise TypeError(f"Expected `{self.__class__.__name__}`, not {type(other)}.")

--- a/ondemandutils/models/_model.py
+++ b/ondemandutils/models/_model.py
@@ -87,6 +87,24 @@ class BaseModel(UserDict):
     def __repr__(self):
         return f"{self.__class__.__name__}({', '.join(f'{k}={v}' for k, v in self.items())})"
 
+    def __or__(self, other):
+        if not isinstance(other, type(self)):
+            raise TypeError(f"Expected `{self.__class__.__name__}`, not {type(other)}.")
+
+        super().__or__(other)
+
+    def __ror__(self, other):
+        if not isinstance(other, type(self)):
+            raise TypeError(f"Expected `{self.__class__.__name__}`, not {type(other)}.")
+
+        super().__ror__(other)
+
+    def __ior__(self, other):
+        if not isinstance(other, type(self)):
+            raise TypeError(f"Expected `{self.__class__.__name__}`, not {type(other)}.")
+
+        super().__ior__(other)
+
     @classmethod
     def from_dict(cls, dict_obj: Dict[str, Any]):
         """Construct data model object using a dictionary object."""

--- a/ondemandutils/models/_model.py
+++ b/ondemandutils/models/_model.py
@@ -91,19 +91,19 @@ class BaseModel(UserDict):
         if not isinstance(other, type(self)):
             raise TypeError(f"Expected `{self.__class__.__name__}`, not {type(other)}.")
 
-        super().__or__(other)
+        return super().__or__(other)
 
     def __ror__(self, other):
         if not isinstance(other, type(self)):
             raise TypeError(f"Expected `{self.__class__.__name__}`, not {type(other)}.")
 
-        super().__ror__(other)
+        return super().__ror__(other)
 
     def __ior__(self, other):
         if not isinstance(other, type(self)):
             raise TypeError(f"Expected `{self.__class__.__name__}`, not {type(other)}.")
 
-        super().__ior__(other)
+        return super().__ior__(other)
 
     @classmethod
     def from_dict(cls, dict_obj: Dict[str, Any]):

--- a/ondemandutils/models/nginx_stage.py
+++ b/ondemandutils/models/nginx_stage.py
@@ -14,6 +14,8 @@
 
 """Data models for the `nginx_stage.yml` configuration file."""
 
+from typing import Any, Dict
+
 from ._model import BaseModel, base_descriptors
 from ._options import NginxStageOptions
 
@@ -21,8 +23,8 @@ from ._options import NginxStageOptions
 class NginxStageConfig(BaseModel):
     """Data model representing the `nginx_stage.yml` configuration file."""
 
-    def __init__(self, **kwargs) -> None:
-        super().__init__(validator=NginxStageOptions, **kwargs)
+    def __init__(self, obj: Dict[str, Any] = None, /, **kwargs) -> None:
+        super().__init__(obj, **kwargs, validator=NginxStageOptions)
 
 
 # Generate descriptors for accessing `nginx_stage.yml` configuration options.

--- a/ondemandutils/models/ood_portal.py
+++ b/ondemandutils/models/ood_portal.py
@@ -37,6 +37,25 @@ class OODPortalConfig(BaseModel):
     def __init__(self, **kwargs) -> None:
         super().__init__(validator=OODPortalOptions, **kwargs)
 
+    def __getitem__(self, key):
+        value = super().__getitem__(key)
+        if key == "dex":
+            return DexConfig(**value)
+
+        return value
+
+    def __setitem__(self, key, value):
+        if key == "dex" and not isinstance(value, DexConfig):
+            try:
+                v = value or {}
+                value = DexConfig(**v)
+            except AttributeError:
+                raise TypeError(
+                    f"Expected `{DexConfig.__name__}` for key '{key}', not {type(value)}."
+                )
+
+        super().__setitem__(key, value)
+
     @property
     def dex(self) -> DexConfig:
         """Get Dex IDP service configuration."""

--- a/ondemandutils/models/ood_portal.py
+++ b/ondemandutils/models/ood_portal.py
@@ -40,18 +40,18 @@ class OODPortalConfig(BaseModel):
     @property
     def dex(self) -> DexConfig:
         """Get Dex IDP service configuration."""
-        return DexConfig(**self._register["dex"])
+        return DexConfig(**self["dex"])
 
     @dex.setter
     @assert_type(value=DexConfig)
     def dex(self, value: DexConfig) -> None:
         """Set new Dex IDP service configuration."""
-        self._register["dex"] = value.dict()
+        self["dex"] = value.dict()
 
     @dex.deleter
     def dex(self) -> None:
         """Delete Dex IDP service configuration."""
-        self._register["dex"] = {}
+        self["dex"] = {}
 
 
 # Generate descriptors for accessing `ood_portal.yml` configuration options.

--- a/ondemandutils/models/ood_portal.py
+++ b/ondemandutils/models/ood_portal.py
@@ -14,6 +14,8 @@
 
 """Data models for the `ood_portal.yml` configuration file."""
 
+from typing import Any, Dict
+
 from ._model import BaseModel, assert_type, base_descriptors
 from ._options import DexOptions, OODPortalOptions
 
@@ -21,8 +23,8 @@ from ._options import DexOptions, OODPortalOptions
 class DexConfig(BaseModel):
     """Data model representing Dex configuration inside `ood_portal.yml`."""
 
-    def __init__(self, **kwargs) -> None:
-        super().__init__(validator=DexOptions, **kwargs)
+    def __init__(self, obj: Dict[str, Any] = None, /, **kwargs) -> None:
+        super().__init__(obj, **kwargs, validator=DexOptions)
 
 
 # Generate descriptors for accessing Dex configuration options.
@@ -34,8 +36,8 @@ for e in DexOptions:
 class OODPortalConfig(BaseModel):
     """Data model representing the `ood_portal.yml` configuration file."""
 
-    def __init__(self, **kwargs) -> None:
-        super().__init__(validator=OODPortalOptions, **kwargs)
+    def __init__(self, obj: Dict[str, Any] = None, /, **kwargs) -> None:
+        super().__init__(obj, **kwargs, validator=OODPortalOptions)
 
     def __getitem__(self, key):
         value = super().__getitem__(key)
@@ -59,7 +61,7 @@ class OODPortalConfig(BaseModel):
     @property
     def dex(self) -> DexConfig:
         """Get Dex IDP service configuration."""
-        return DexConfig(**self["dex"])
+        return self["dex"]
 
     @dex.setter
     @assert_type(value=DexConfig)

--- a/tests/unit/editors/test_ood_portal.py
+++ b/tests/unit/editors/test_ood_portal.py
@@ -94,7 +94,6 @@ dex:
   client_name: OnDemand
   client_secret: /etc/ood/dex/ondemand.secret
   client_redirect_uris: []
-  static_clients: []
   connectors:
     - type: ldap
       id: ldap

--- a/tests/unit/editors/test_ood_portal.py
+++ b/tests/unit/editors/test_ood_portal.py
@@ -19,7 +19,7 @@ import unittest
 from pathlib import Path
 
 from ondemandutils.editors import ood_portal
-from ondemandutils.models import OODPortalConfig, DexConfig
+from ondemandutils.models import DexConfig, OODPortalConfig
 
 example_ood_portal_yml = r"""#
 # `ood_portal.yml` generated at 2024-03-05 09:59:02.084563 by ondemandutils.
@@ -132,7 +132,7 @@ class TestDexConfigEditor(unittest.TestCase):
         Path("ood_portal.yaml").write_text(example_ood_portal_yml)
 
     def test_dex_config(self) -> None:
-        """Test setting a Dex service configuration in `ood_portal.yml`"""
+        """Test setting a Dex service configuration in `ood_portal.yml`."""
         dex_config = DexConfig()
         dex_config.http_port = 5556
         dex_config.tls_cert = "/var/snap/ondemand/common/tls.cert"

--- a/tests/unit/models/test_base_model.py
+++ b/tests/unit/models/test_base_model.py
@@ -1,0 +1,69 @@
+# Copyright 2024 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Unit tests for the `BaseModel` class that all data models inherit from."""
+
+import unittest
+
+from ondemandutils.models import NginxStageConfig, OODPortalConfig
+
+
+class TestBaseModel(unittest.TestCase):
+    """Unit tests for the `BaseModel` parent class."""
+
+    def test_merge(self) -> None:
+        """Test the `__or__`, `__ror__`, and `__ior__` magic methods."""
+        portal_conf_1 = OODPortalConfig.from_dict(
+            {"servername": "10.69.205.59", "logroot": "/var/log", "lua_log_level": "debug"}
+        )
+        portal_conf_2 = OODPortalConfig.from_dict(
+            {
+                "lua_root": "/usr/local/ood/mod_ood_proxy/lib",
+                "server_aliases": ["ondemand.ubuntu.com", "ondemand.charmed-hpc.rocks"],
+                "auth": ["AuthType openid-connect", "Require valid-user"],
+                "user_env": [{"PATH": "/opt/bin:$PATH"}],
+            }
+        )
+
+        new_portal_1 = portal_conf_1 | portal_conf_2
+        new_portal_2 = portal_conf_2 | portal_conf_1
+        portal_conf_1 |= portal_conf_2
+        self.assertDictEqual(new_portal_1.dict(), new_portal_2.dict())
+        self.assertDictEqual(portal_conf_1.dict(), new_portal_1.dict())
+
+    def test_bad_merge(self) -> None:
+        """Test the `__or__`, `__ror__`, and `__ior__` magic methods with bad inputs."""
+        portal_conf = OODPortalConfig.from_dict(
+            {"servername": "10.69.205.59", "logroot": "/var/log", "lua_log_level": "debug"}
+        )
+        nginx_stage_conf = NginxStageConfig.from_dict(
+            {
+                "passenger_ruby": "/snap/ondemand/common/usr/bin/ruby",
+                "passenger_nodejs": "/snap/ondemand/common/bin/node",
+                "passenger_python": "/snap/ondemand/common/bin/python3",
+                "pun_custom_env_declarations": [
+                    "PATH",
+                    "LD_LIBRARY_PATH",
+                    "MANPATH",
+                    "SCLS",
+                    "X_SCLS",
+                    "CPATH",
+                ],
+            }
+        )
+
+        with self.assertRaises(TypeError):
+            _ = portal_conf | nginx_stage_conf
+            _ = nginx_stage_conf | portal_conf
+            portal_conf |= nginx_stage_conf


### PR DESCRIPTION
By making `BaseModel` in `ondemandutils.models._model` inherit from `collections.UserList`, the functionality of `OODPortalConfig`, `DexConfig`, and `NginxStageConfig` is extended. This extension of the data models' capabilities makes it much easier to perform comparisons and dictionary merges when evaluating updates to Open OnDemand's configuration.

Also, by inheriting from `collections.UserList`, less reimplementation is required in the data model classes. Instead the necessary overrides can be applied and then the data models can default to the implementation in UserList and/or BaseModel.